### PR TITLE
chore: trim scripts, tests and analysis config from the published archive

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -51,10 +51,27 @@ example/out/
 
 # ---- 公開アーカイブにのみ不要なもの ----
 
+# 公開アーカイブは「利用者がパッケージを使う・評価するために必要なもの」に絞る。
+# pub.dev のスコアが要求するのは pubspec.yaml / LICENSE / README / CHANGELOG /
+# 実例（example/）/ lib/ であり、以下はいずれも該当しない。
+# CHANGELOG に記載しない種類の変更と同じ線引き（AGENTS.md「ドキュメントと履歴管理」）。
+
 # 開発者・エージェント向けドキュメント。
-# 利用者向けの情報は README.md / README_ja.md / example/ に集約しており、
-# 以下はリポジトリで参照するもの。CHANGELOG に記載しない種類の文書と
-# 同じ線引きで公開対象からも外す（AGENTS.md「ドキュメントと履歴管理」を参照）。
+# 利用者向けの情報は README.md / README_ja.md / example/ に集約している。
 AGENTS.md
 CLAUDE.md
 doc/
+
+# 開発用スクリプトとその呼び出し口。リポジトリ内でのみ使う。
+scripts/
+Makefile
+make.ps1
+
+# テストコード。pub.dev はテストを実行しない（スコアリングは pana による
+# 静的解析のみ）ため、同梱しても利用者にも pub.dev にも利用されない。
+test/
+
+# 静的解析設定。pana は自前の設定で解析するため同梱は不要。
+# 同梱すると very_good_analysis のルールが pub.dev 側の解析にも上乗せされ、
+# ルール追加でスコアが下がる余地が生まれる。
+analysis_options.yaml


### PR DESCRIPTION
## 概要 (Summary)

公開アーカイブから `scripts/` / `Makefile` / `make.ps1` / `test/` / `analysis_options.yaml` を除外しました。#38 で `AGENTS.md` / `CLAUDE.md` / `doc/` を除外した続きです。リポジトリ内のファイルは削除していません（`.pubignore` は公開時のみに影響します）。

---

## 変更内容 (What)

`.pubignore` に以下を追加。

| 対象 | 除外する理由 |
| --- | --- |
| `scripts/`, `Makefile`, `make.ps1` | リポジトリ内でのみ使う開発用スクリプトとその呼び出し口 |
| `test/` | pub.dev はテストを実行しない（後述） |
| `analysis_options.yaml` | pana は自前の解析設定を用意するため同梱不要（後述） |

## 理由 (Why)

公開アーカイブは利用者がダウンロードするものであり、パッケージを使う・評価するために必要なものだけで足ります。pub.dev のスコアが要求するのは `pubspec.yaml` / `LICENSE` / `README.md` / `CHANGELOG.md` / 実例（`example/`）/ `lib/` です。

## 判断の根拠（調査結果）

方針を決めるにあたり、推測ではなく一次情報を確認しました。

### pub.dev はテストを実行しない

[pub.dev のスコアリング](https://pub.dev/help/scoring)のカテゴリは「Dart ファイル規約」「ドキュメント」「プラットフォーム対応」「静的解析」「依存の新しさ」の5つで、いずれもテスト実行を含みません。スコアリングは `pana` による静的解析で完結します。したがって `test/`（26ファイル・約 70 KB）を同梱しても、利用者にも pub.dev にも使われません。

### `analysis_options.yaml` が無くても静的解析は走る

`pana` は自前の解析設定（標準 [lints](https://pub.dev/packages/lints) ベース）を用意して解析します。パッケージ側に `analysis_options.yaml` があれば `include:` や追加の lint ルール、`formatter:` 設定を取り込んでマージしますが（[pana の `updatePassthroughOptions`](https://github.com/dart-lang/pana/blob/master/lib/src/analysis_options.dart)）、無くても解析は問題なく実行されます。

同梱した場合、本パッケージの `include: package:very_good_analysis/analysis_options.yaml` が pub.dev 側の解析にも上乗せされます。現状ローカルで違反ゼロのため実害はありませんが、`very_good_analysis` の更新でルールが増えた際にスコアが下がる余地が生まれるため、外すほうが安全と判断しました。

### 一般的な慣行との関係

[公式ドキュメント](https://dart.dev/tools/pub/publishing)は「パッケージルート配下の全ファイルを含む（ドット始まりと ignore 対象を除く）」「ほとんどのパッケージに `.pubignore` は不要」としています。つまり `test/` などが公開されているのが一般的ですが、それは推奨だからではなく絞り込みをしていないためです。本 PR は意図的に絞り込む選択をしています。

## 変更項目の詳細（必須）

- **変更内容**: `.pubignore` に `scripts/`, `Makefile`, `make.ps1`, `test/`, `analysis_options.yaml` を追加。各行に判断理由をコメントで併記。
- **理由**: 上記のとおり。
- **差分への参照**: `.pubignore`
- **テスト**: `.pubignore` は公開時のみに作用するため、ローカルの開発体験は不変。実際に `dart analyze`（`No issues found!` — `analysis_options.yaml` はリポジトリに残っているため `very_good_analysis` が引き続き適用される）、`dart test`（91件パス）、`dart format`（差分なし）を確認済み。
- **リスク/後続作業**: 公開 API・挙動ともに変更なし。利用者がアーカイブ内のテストやスクリプトを参照していた場合は影響し得るが、いずれもパッケージの利用に必要なものではない。

## 検証

`.pubignore` 更新の前後で `dart pub publish --dry-run` のファイル一覧を取得して比較し、最終的な公開内容が意図どおりであることを確認しました。

```
CHANGELOG.md / LICENSE / README.md / README_ja.md / pubspec.yaml
bin/locale_sheet.dart
example/  (README.md, README_ja.md, sample.xlsx)
lib/      (locale_sheet.dart, src/ 配下 13ファイル)

Total compressed archive size: 46 KB -> 31 KB
Package has 0 warnings.
```

一連の絞り込みでの推移: 59 KB（#38 以前） → 46 KB（#38） → 31 KB（本 PR）。

## チェックリスト

- [x] テストを実行し、すべて成功した（91件パス）
- [x] `dart analyze` を実行し、エラーや重要な警告を解消した（`No issues found!`）
- [x] カバレッジを測定し、必要があればテストを追加した（ソース変更なしのため追加なし）
- [x] `CHANGELOG.md` を更新した — #38 で定めた基準（「この行を読んだ利用者が、自分のコードや使い方を変える必要があるか」）に照らし、同梱ファイルが減っても使い方は変わらないため新規エントリは追加していない
- [ ] `README.md` / `README_ja.md` を更新 — 外部仕様の変更が無いため対象外

## 関連 Issue / PR

- #38 — `AGENTS.md` / `CLAUDE.md` / `doc/` を除外し、`.pubignore` を追加した PR。本 PR はその続き。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
