### PR TITLE
test: add e2e tests on the real sample workbook and close coverage gaps

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # example/*.xlsx は Git LFS 管理（.gitattributes）。
+          # 既定ではポインタファイルのままチェックアウトされ、実ファイルを
+          # 読む e2e テストが解析に失敗するため実体を取得する。
+          lfs: true
       
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vx.x.x 20xx-xx-xx
 
+- fix: `LocalizationEntry` equality and `hashCode` now compare placeholders by value. Two entries holding identical placeholders previously never compared equal, because each comparison converted the placeholders to fresh `Map` instances. Entries without placeholders were unaffected.
 - feat: warn when the same key appears in more than one row. The CLI now logs a `WARNING` per duplicated key, and `LocalizationSheet.duplicateKeys` exposes the list for library users. Export behavior is unchanged (later rows still win per locale).
 - docs: fix the Quick Start dependency snippet in `README.md` / `README_ja.md` — `locale_sheet` was not indented under `dev_dependencies`, so the snippet was invalid YAML as written, and the version was still `^0.4.0`.
 - docs: document the `--color` / `--no-color` option, which was missing from the CLI option list in both READMEs.

--- a/lib/src/core/localization_entry.dart
+++ b/lib/src/core/localization_entry.dart
@@ -89,10 +89,10 @@ class LocalizationEntry {
         other.key == key &&
         mapEquals(other.translations, translations) &&
         other.description == description &&
-        mapEquals(
-          other.placeholders.map((k, v) => MapEntry(k, v.toMap())),
-          placeholders.map((k, v) => MapEntry(k, v.toMap())),
-        );
+        // Placeholder は値による等価比較を実装しているため、Map へ変換せず
+        // そのまま比較する。変換すると毎回新しい Map インスタンスが作られ、
+        // 内容が同じでも常に不一致になってしまう。
+        mapEquals(other.placeholders, placeholders);
   }
 
   @override
@@ -100,6 +100,6 @@ class LocalizationEntry {
     key,
     mapHash(translations),
     description,
-    mapHash(placeholders.map((k, v) => MapEntry(k, v.toMap()))),
+    mapHash(placeholders),
   );
 }

--- a/test/src/cli/export_runner_test.dart
+++ b/test/src/cli/export_runner_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:args/args.dart';
 import 'package:locale_sheet/locale_sheet.dart';
 import 'package:locale_sheet/src/cli/export_runner.dart';
+import 'package:locale_sheet/src/cli/logger.dart';
 import 'package:test/test.dart';
 
 import '../../test_helpers/logger.dart';
@@ -599,6 +600,198 @@ void main() {
     } finally {
       await tmp.delete();
     }
+  });
+
+  /// 自動検出を有効にせず未定義時の扱いだけを指定した場合、
+  /// そのオプションが無視される旨を警告することを検証
+  /// Arrange-Act-Assertパターン
+  test(
+    'warns when treat-undefined-placeholders is set without auto-detection',
+    () async {
+      // Arrange: --auto-detect-placeholders を付けずに treat だけ指定する
+      final logger = TestLogger();
+      final entry = LocalizationEntry('items_count', const {
+        'en': 'You have {count} items.',
+      });
+      final sheet = LocalizationSheet(locales: const ['en'], entries: [entry]);
+      final parser = _FakeParser(sheet, sheets: ['Sheet1']);
+      final exporter = _FakeExporter();
+
+      final tmp = File('test/tmp_export_runner_treat_only.xlsx');
+      await tmp.writeAsBytes([0]);
+
+      try {
+        final args = ExportCommand().argParser.parse([
+          '--input',
+          tmp.path,
+          '--format',
+          'arb',
+          '--out',
+          'outdir',
+          '--treat-undefined-placeholders',
+          'warn',
+          '--default-locale',
+          'en',
+        ]);
+
+        final runner = ExportRunner(
+          logger: logger,
+          parser: parser,
+          exporters: {'arb': exporter},
+        );
+
+        // Act
+        final res = await runner.run(args);
+
+        // Assert: 警告は出るが処理は成功し、検出も行われない
+        expect(res, equals(0));
+        expect(
+          logger.infos.any(
+            (s) => s.contains(
+              '--treat-undefined-placeholders was provided but',
+            ),
+          ),
+          isTrue,
+        );
+        expect(exporter.lastSheet!.entries.first.placeholders, isEmpty);
+      } finally {
+        await tmp.delete();
+      }
+    },
+  );
+
+  /// treat=error で未定義プレースホルダを検出した場合に
+  /// 終了コード1で中断し、エクスポートが行われないことを検証
+  /// Arrange-Act-Assertパターン
+  test('auto-detect error aborts with exit code 1 before exporting', () async {
+    // Arrange
+    final logger = TestLogger();
+    final entry = LocalizationEntry('items_count', const {
+      'en': 'You have {count} items.',
+    });
+    final sheet = LocalizationSheet(locales: const ['en'], entries: [entry]);
+    final parser = _FakeParser(sheet, sheets: ['Sheet1']);
+    final exporter = _FakeExporter();
+
+    final tmp = File('test/tmp_export_runner_error.xlsx');
+    await tmp.writeAsBytes([0]);
+
+    try {
+      final args = ExportCommand().argParser.parse([
+        '--input',
+        tmp.path,
+        '--format',
+        'arb',
+        '--out',
+        'outdir',
+        '--auto-detect-placeholders',
+        '--treat-undefined-placeholders',
+        'error',
+        '--default-locale',
+        'en',
+      ]);
+
+      final runner = ExportRunner(
+        logger: logger,
+        parser: parser,
+        exporters: {'arb': exporter},
+      );
+
+      // Act
+      final res = await runner.run(args);
+
+      // Assert: 中断されるためエクスポーターは呼ばれない
+      expect(res, equals(1));
+      expect(
+        logger.errors.any(
+          (s) => s.contains('Undefined placeholder detected'),
+        ),
+        isTrue,
+      );
+      expect(exporter.lastSheet, isNull);
+    } finally {
+      await tmp.delete();
+    }
+  });
+
+  /// --placeholder-default-type で指定した型が自動追加時に使われることを検証
+  /// Arrange-Act-Assertパターン
+  test('auto-detect add honors placeholder-default-type', () async {
+    // Arrange
+    final logger = TestLogger();
+    final entry = LocalizationEntry('items_count', const {
+      'en': 'You have {count} items.',
+    });
+    final sheet = LocalizationSheet(locales: const ['en'], entries: [entry]);
+    final parser = _FakeParser(sheet, sheets: ['Sheet1']);
+    final exporter = _FakeExporter();
+
+    final tmp = File('test/tmp_export_runner_type.xlsx');
+    await tmp.writeAsBytes([0]);
+
+    try {
+      final args = ExportCommand().argParser.parse([
+        '--input',
+        tmp.path,
+        '--format',
+        'arb',
+        '--out',
+        'outdir',
+        '--auto-detect-placeholders',
+        '--treat-undefined-placeholders',
+        'add',
+        '--placeholder-default-type',
+        'int',
+        '--default-locale',
+        'en',
+      ]);
+
+      final runner = ExportRunner(
+        logger: logger,
+        parser: parser,
+        exporters: {'arb': exporter},
+      );
+
+      // Act
+      final res = await runner.run(args);
+
+      // Assert: 既定の String ではなく指定した int が使われる
+      expect(res, equals(0));
+      final outEntry = exporter.lastSheet!.entries.first;
+      expect(outEntry.placeholders['count']!.type, equals('int'));
+    } finally {
+      await tmp.delete();
+    }
+  });
+
+  /// ロガーを差し替えていない場合（既定の SimpleLogger）でも
+  /// エラーが報告され終了コード1を返すことを検証
+  /// Arrange-Act-Assertパターン
+  test('reports errors through the default SimpleLogger', () async {
+    // Arrange: SimpleLogger を渡すと内部で色設定を反映した別インスタンスが
+    // 作られるため、ロガーが同一でない場合のエラー出力経路を通る
+    final sheet = LocalizationSheet(locales: const ['en'], entries: []);
+    final runner = ExportRunner(
+      logger: SimpleLogger(color: false),
+      parser: _FakeParser(sheet),
+      exporters: {'arb': _FakeExporter()},
+    );
+
+    final args = argParser().parse([
+      '--input',
+      'test/no_such_input_file.xlsx',
+      '--format',
+      'arb',
+      '--out',
+      'outdir',
+      '--no-color',
+    ]);
+
+    // Act: 入力ファイルが存在しないため読み込みで失敗する
+    final res = await runner.run(args);
+
+    // Assert
+    expect(res, equals(1));
   });
 
   test('auto-detect ignore does not log warning and does not add', () async {

--- a/test/src/core/localization_entry_test.dart
+++ b/test/src/core/localization_entry_test.dart
@@ -56,6 +56,42 @@ void main() {
     expect(e3.translations['ja'], isNull);
   });
 
+  /// プレースホルダを含むエントリがtoMap/fromMapで往復できることと、
+  /// placeholders内の不正な要素が無視されることを検証
+  /// Arrange-Act-Assertパターン
+  test('LocalizationEntry round-trips placeholders through toMap/fromMap', () {
+    // Arrange
+    final original = LocalizationEntry(
+      'items_count',
+      const {'en': 'You have {count} items.'},
+      description: 'item counter',
+      placeholders: const {
+        'count': Placeholder(type: 'int', example: '3', source: 'declared'),
+      },
+    );
+
+    // Act
+    final restored = LocalizationEntry.fromMap(
+      Map<String, dynamic>.from(original.toMap()),
+    );
+
+    // Assert: プレースホルダの各フィールドが保持される
+    expect(restored.placeholders.keys, ['count']);
+    final ph = restored.placeholders['count']!;
+    expect(ph.type, 'int');
+    expect(ph.example, '3');
+    expect(ph.source, 'declared');
+    expect(restored, equals(original));
+
+    // placeholders の値がMapでない場合はそのエントリを無視する
+    const invalid = {
+      'key': 'k',
+      'placeholders': {'bad': 'not-a-map'},
+    };
+    final fromInvalid = LocalizationEntry.fromMap(invalid);
+    expect(fromInvalid.placeholders, isEmpty);
+  });
+
   /// LocalizationEntryの等価性・hashCodeの境界値を検証
   /// Arrange-Act-Assertパターン
   test('LocalizationEntry equality and hashCode edge', () {
@@ -66,5 +102,34 @@ void main() {
     expect(a, equals(b));
     expect(a == c, isFalse);
     expect(a.hashCode, equals(b.hashCode));
+  });
+
+  /// プレースホルダを持つエントリ同士でも、内容が同じなら等価と判定され
+  /// hashCodeも一致することを検証（Placeholderの値比較が使われること）
+  /// Arrange-Act-Assertパターン
+  test('LocalizationEntry equality accounts for placeholder values', () {
+    // Arrange: 同じ内容のプレースホルダを持つ別インスタンス
+    final a = LocalizationEntry(
+      'k',
+      const {'en': 'v {n}'},
+      placeholders: const {'n': Placeholder(type: 'int')},
+    );
+    final b = LocalizationEntry(
+      'k',
+      const {'en': 'v {n}'},
+      placeholders: const {'n': Placeholder(type: 'int')},
+    );
+    final differentType = LocalizationEntry(
+      'k',
+      const {'en': 'v {n}'},
+      placeholders: const {'n': Placeholder(type: 'String')},
+    );
+    final noPlaceholder = LocalizationEntry('k', const {'en': 'v {n}'});
+
+    // Act & Assert
+    expect(a, equals(b));
+    expect(a.hashCode, equals(b.hashCode));
+    expect(a == differentType, isFalse);
+    expect(a == noPlaceholder, isFalse);
   });
 }

--- a/test/src/core/parser_test.dart
+++ b/test/src/core/parser_test.dart
@@ -158,6 +158,23 @@ void main() {
     );
   });
 
+  /// ヘッダ行すら無い（行数0の）シートでも例外にせず
+  /// 空のシートモデルを返すことを検証
+  /// Arrange-Act-Assertパターン
+  test('parse returns an empty sheet when the sheet has no rows at all', () {
+    // Arrange: 一度も書き込んでいないシートは行数0になる
+    final excel = Excel.createExcel();
+    expect(excel.tables[excel.getDefaultSheet()]!.rows, isEmpty);
+    final parser = ExcelParser(decoder: (_) => excel);
+
+    // Act
+    final sheet = parser.parse(Uint8List(0));
+
+    // Assert: ヘッダ検証に到達せず、空の結果が返る
+    expect(sheet.locales, isEmpty);
+    expect(sheet.entries, isEmpty);
+  });
+
   test('getSheetNames returns available sheet names via decoder', () {
     final excel = Excel.createExcel();
     excel['Alpha'].appendRow([TextCellValue('key')]);

--- a/test/src/e2e_sample_xlsx_test.dart
+++ b/test/src/e2e_sample_xlsx_test.dart
@@ -1,0 +1,212 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:locale_sheet/locale_sheet.dart';
+import 'package:test/test.dart';
+
+import '../test_helpers/logger.dart';
+
+/// 出荷している `example/sample.xlsx` を実際に読み込み、CLI と同じ経路で
+/// ARB を生成して内容を全文で検証する e2e テスト。
+///
+/// 他のテストは `Excel.createExcel()` でメモリ上に組み立てたワークブックを
+/// 使うため、実際の表計算ソフトが書き出したファイル（共有文字列を参照する
+/// 形式）の解析経路が検証されない。本テストはその経路と、モデルから ARB を
+/// 書き出す最終段までを通しで確認し、同時に配布しているサンプル自体の
+/// 回帰も検出する。
+void main() {
+  late Directory tmp;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('locale_sheet_e2e');
+  });
+
+  tearDown(() {
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  /// CLI と同じ `CommandRunner` 経由で export を実行します。
+  /// パーサもエクスポーターも実物を使い、ロガーだけテスト用に差し替えます。
+  Future<int?> runExport(List<String> extraArgs) {
+    final runner = CommandRunner<int>('locale_sheet', 'e2e')
+      ..addCommand(ExportCommand(logger: TestLogger()));
+    return runner.run([
+      'export',
+      '--input',
+      'example/sample.xlsx',
+      '--out',
+      tmp.path,
+      ...extraArgs,
+    ]);
+  }
+
+  String readArb(String fileName) =>
+      File('${tmp.path}/$fileName').readAsStringSync();
+
+  List<String> outputFileNames() =>
+      tmp.listSync().map((e) => e.uri.pathSegments.last).toList()..sort();
+
+  /// 実ファイルの Sheet1 を説明列付きで変換し、生成される全 ARB の内容を検証
+  /// Arrange-Act-Assertパターン
+  test('exports Sheet1 with descriptions from the real workbook', () async {
+    // Arrange / Act
+    final code = await runExport([
+      '--sheet-name',
+      'Sheet1',
+      '--default-locale',
+      'en',
+      '--description-header',
+      'description',
+    ]);
+
+    // Assert: ロケール列は5つ。`description` と `備考` はロケールとして扱われない
+    expect(code, equals(0));
+    expect(outputFileNames(), [
+      'app_en.arb',
+      'app_ja.arb',
+      'app_zh.arb',
+      'app_zh_Hant_HK.arb',
+      'app_zh_TW.arb',
+    ]);
+
+    // デフォルトロケールにのみ `@<key>` メタデータが出力される
+    expect(readArb('app_en.arb'), '''
+{
+  "@bye": {
+    "description": "the text 'Goodbye'"
+  },
+  "bye": "Goodbye",
+  "@hello": {
+    "description": "the text 'Hello'"
+  },
+  "hello": "Hello",
+  "@likeFoodFluit": {},
+  "likeFoodFluit": "I like {food} and {fluit}.",
+  "@@locale": "en"
+}''');
+
+    // 非デフォルトロケールにはメタデータを含めない
+    expect(readArb('app_ja.arb'), '''
+{
+  "bye": "さようなら",
+  "hello": "こんにちは",
+  "likeFoodFluit": "私は{food}と{fluit}が好き",
+  "@@locale": "ja"
+}''');
+
+    // ハイフン区切りのヘッダはファイル名も @@locale もアンダースコアに正規化される
+    expect(readArb('app_zh_Hant_HK.arb'), '''
+{
+  "bye": "再見",
+  "hello": "你好",
+  "likeFoodFluit": "我喜歡{food}和{fluit}",
+  "@@locale": "zh_Hant_HK"
+}''');
+  });
+
+  /// 自動検出したプレースホルダが ARB のメタデータとして書き出されることを検証
+  /// Arrange-Act-Assertパターン
+  test('writes auto-detected placeholders into the default ARB', () async {
+    // Arrange / Act
+    final code = await runExport([
+      '--sheet-name',
+      'Sheet1',
+      '--default-locale',
+      'en',
+      '--description-header',
+      'description',
+      '--auto-detect-placeholders',
+      '--treat-undefined-placeholders',
+      'add',
+    ]);
+
+    // Assert: `@<key>.placeholders` に検出結果が出力される
+    expect(code, equals(0));
+    expect(readArb('app_en.arb'), '''
+{
+  "@bye": {
+    "description": "the text 'Goodbye'"
+  },
+  "bye": "Goodbye",
+  "@hello": {
+    "description": "the text 'Hello'"
+  },
+  "hello": "Hello",
+  "@likeFoodFluit": {
+    "placeholders": {
+      "food": {
+        "type": "String",
+        "source": "detected"
+      },
+      "fluit": {
+        "type": "String",
+        "source": "detected"
+      }
+    }
+  },
+  "likeFoodFluit": "I like {food} and {fluit}.",
+  "@@locale": "en"
+}''');
+  });
+
+  /// 説明列を指定しない場合、ロケールでない列が単に無視されることを検証
+  /// Arrange-Act-Assertパターン
+  test('ignores non-locale columns without a description header', () async {
+    // Arrange / Act
+    final code = await runExport([
+      '--sheet-name',
+      'Sheet1',
+      '--default-locale',
+      'en',
+    ]);
+
+    // Assert: `description` 列は説明として使われず、専用の ARB も作られない
+    expect(code, equals(0));
+    expect(outputFileNames(), [
+      'app_en.arb',
+      'app_ja.arb',
+      'app_zh.arb',
+      'app_zh_Hant_HK.arb',
+      'app_zh_TW.arb',
+    ]);
+    expect(readArb('app_en.arb'), '''
+{
+  "@bye": {},
+  "bye": "Goodbye",
+  "@hello": {},
+  "hello": "Hello",
+  "@likeFoodFluit": {},
+  "likeFoodFluit": "I like {food} and {fluit}.",
+  "@@locale": "en"
+}''');
+  });
+
+  /// シート指定で別のロケール構成を持つシートを変換し、`en` が無い場合に
+  /// 最初のロケール列がデフォルトになることを検証
+  /// Arrange-Act-Assertパターン
+  test('exports Sheet2 and falls back to the first locale', () async {
+    // Arrange / Act
+    final code = await runExport(['--sheet-name', 'Sheet2']);
+
+    // Assert: Sheet2 のロケールは ja と fr のみ
+    expect(code, equals(0));
+    expect(outputFileNames(), ['app_fr.arb', 'app_ja.arb']);
+
+    // `en` 列が無いため最初のロケール `ja` がデフォルトとなり、
+    // 説明が無いので `@<key>` は空オブジェクトになる
+    expect(readArb('app_ja.arb'), '''
+{
+  "@bye": {},
+  "bye": "さようなら",
+  "@hello": {},
+  "hello": "こんにちは",
+  "@@locale": "ja"
+}''');
+    expect(readArb('app_fr.arb'), '''
+{
+  "bye": "Au revoir",
+  "hello": "Bonjour",
+  "@@locale": "fr"
+}''');
+  });
+}

--- a/test/src/integration_default_exporter_test.dart
+++ b/test/src/integration_default_exporter_test.dart
@@ -25,11 +25,16 @@ void main() {
       // Act: エクスポーター未指定で変換（デフォルトArbExporter使用）
       await convertExcelToArb(inputPath: inFile.path, outDir: outDir);
 
-      // Assert: ARBファイルが生成され、@@localeが含まれる
+      // Assert: ARBファイルが生成され、内容が期待どおりであること。
+      // 既定の defaultLocale は 'en' のため、@<key> メタデータも出力される
       final arbFile = File('$outDir/app_en.arb');
       expect(arbFile.existsSync(), isTrue);
-      final content = arbFile.readAsStringSync();
-      expect(content, contains('@@locale'));
+      expect(arbFile.readAsStringSync(), '''
+{
+  "@hello": {},
+  "hello": "Hello",
+  "@@locale": "en"
+}''');
     } finally {
       // Cleanup
       tmp.deleteSync(recursive: true);


### PR DESCRIPTION
## 概要 (Summary)

出荷している `example/sample.xlsx` を実際に読み込む e2e テストを追加し、未検証だった経路を塞ぎました。その過程で `LocalizationEntry` の等価比較のバグが判明したため、あわせて修正しています。

---

## 変更内容 (What)

- `test/src/e2e_sample_xlsx_test.dart` を新規追加（4ケース）
- `export_runner` の未検証だった4経路にテストを追加
- `parser` の行数0シート経路にテストを追加
- `LocalizationEntry` のプレースホルダ往復と等価性のテストを追加
- **`LocalizationEntry` の `==` / `hashCode` のバグを修正**
- 既存 `integration_default_exporter_test.dart` の緩い assert を全文比較に強化

## 理由 (Why)

### 実ファイルを読むテストが1つも無かった

これまで全テストが `Excel.createExcel()` でメモリ上にワークブックを組み立てており、実際の表計算ソフトが書き出したファイルの解析経路が検証されていませんでした。

`example/sample.xlsx` は Google スプレッドシートからの書き出しで、セル値を共有文字列（`t="s"` + `sharedStrings.xml`）で保持します。一方 `excel` パッケージが生成するファイルは構造が異なります。実ファイル側だけが壊れる回帰を検出できない状態でした。加えて、配布しているサンプル自体が一度も検証されていませんでした。

### ARB 出力の最終段が未検証だった

カバレッジ計測の結果、`arb_exporter.dart` の `@<key>.placeholders` を書き出す部分が**未到達**でした。プレースホルダ自動検出は 0.4.0 の主要機能ですが、テストは検出（`placeholder_detector_test.dart`）とメモリ上のモデルへの反映（`export_runner_test.dart`）までしか見ておらず、CLI 経路のテストはすべて `_FakeExporter` で止まっていたためです。実際に ARB に書き出される部分を誰も検証していませんでした。

## 変更項目の詳細（必須）

### 1. e2e テストの追加

- **変更内容**: `example/sample.xlsx` を `CommandRunner` 経由で実際に変換し、生成された ARB を**全文一致**で検証する4ケースを追加。パーサもエクスポーターも実物を使い、ロガーのみテスト用に差し替え。
  1. `Sheet1` を説明列付きで変換 — 生成ファイル5つの名前、デフォルトロケールのみに `@<key>` が出ること、非デフォルトには出ないこと、`zh-Hant-HK` がファイル名・`@@locale` ともにアンダースコアへ正規化されること
  2. `--auto-detect-placeholders --treat-undefined-placeholders add` — `@<key>.placeholders` に `type` と `source: detected` が出力されること
  3. 説明列を指定しない場合 — `description` / `備考` 列が単に無視され、専用の ARB も作られないこと
  4. `--sheet-name Sheet2` — `en` 列が無いため最初のロケール `ja` がデフォルトになり、説明が無いので `@<key>` が空オブジェクトになること
- **理由**: 上記のとおり。1ファイルで実ファイル解析・説明列・プレースホルダ・複数シート・ロケール正規化の主要経路を通せるため、バイナリ fixture を増やさずに済む。
- **差分への参照**: `test/src/e2e_sample_xlsx_test.dart`
- **テスト**: 本項目がテスト。
- **リスク/後続作業**: `example/sample.xlsx` を変更する際は本テストの期待値も更新が必要。これは意図した結合であり、サンプル変更が無検証で通らなくなる。

**fixture を増やさない方針について**: ケースごとに `.xlsx` を用意する案も検討しましたが採用していません。バイナリを増やすと PR で期待値の変更が読めなくなり、更新のたびに表計算ソフトを開く必要があり、`example/*.xlsx` は Git LFS 管理（`.gitattributes`）でもあるためです。ケース網羅は従来どおりメモリ生成で行い、実ファイル経路の担保だけを e2e に任せる使い分けとしました。

### 2. `LocalizationEntry` の等価比較の修正

- **変更内容**: `==` と `hashCode` で、`placeholders` を `toMap()` した Map に変換せず、そのまま比較・ハッシュするよう変更。
- **理由**: 変換すると比較のたびに新しい `Map` インスタンスが生成され、`mapEquals` の値比較（`!=`）が常に成立してしまうため、**プレースホルダを持つエントリは内容が同一でも決して等価にならず、`hashCode` も一致しませんでした**。`Placeholder` 自身は `==` / `hashCode` を値ベースで実装済みなので、変換は不要かつ有害でした。プレースホルダを持たないエントリ（空 Map 同士）は影響を受けないため、これまで顕在化していませんでした。`doc/requirements.md` の FR-96「エントリとプレースホルダは不変とし、値による等価比較が可能であること」に対する違反にあたります。
- **差分への参照**: `lib/src/core/localization_entry.dart`
- **テスト**: `LocalizationEntry equality accounts for placeholder values` を追加。同一内容の別インスタンスが等価かつ同一 `hashCode` になること、型が違えば不一致になること、プレースホルダの有無で不一致になることを検証。修正前は最初の assert で失敗します。
- **リスク/後続作業**: 挙動が変わるのは「これまで常に false だった比較が正しく true になる」方向のみ。等価判定が false であることに依存したコードがあれば影響するが、それは元々バグに依存していたことになる。

### 3. 未到達だった分岐へのテスト追加

- **変更内容**:
  - `--treat-undefined-placeholders` を `--auto-detect-placeholders` 無しで指定した場合の警告（FR-57）
  - `--treat-undefined-placeholders=error` で終了コード1で中断し、エクスポーターが呼ばれないこと（FR-53）
  - `--placeholder-default-type` で指定した型が自動追加に使われること（FR-54）
  - 既定の `SimpleLogger` 使用時のエラー出力経路
  - 行数0のシートを解析しても例外にならず空の結果を返すこと（FR-06）
  - `LocalizationEntry.fromMap` によるプレースホルダの復元と、値が Map でない要素の無視（FR-94）
- **理由**: いずれも仕様として定義済みだが検証されていなかった。
- **差分への参照**: `test/src/cli/export_runner_test.dart`, `test/src/core/parser_test.dart`, `test/src/core/localization_entry_test.dart`
- **テスト**: 本項目がテスト。
- **リスク/後続作業**: `SimpleLogger` を使うテストは標準出力・標準エラーに実際に出力するため、テスト実行時にログが数行表示されます。出力先を差し替えるには `IOOverrides` で `Stdout` を実装する必要があり、得られる価値に対して複雑すぎると判断しました。

### 4. 既存 integration テストの強化

- **変更内容**: `contains('@@locale')` のみだった assert を ARB 全文の一致比較に変更。
- **理由**: ファイルが生成されたことしか保証しておらず、内容の回帰を検出できなかった。
- **差分への参照**: `test/src/integration_default_exporter_test.dart`
- **テスト**: 本項目がテスト。
- **リスク/後続作業**: なし。

## カバレッジ

| ファイル | 変更前 | 変更後 |
| --- | --- | --- |
| `arb_exporter.dart` | 89.7% | **100%** |
| `export_runner.dart` | 90.6% | 98.1% |
| `localization_entry.dart` | 95.5% | **100%** |
| `parser.dart` | 95.8% | 97.2% |
| **合計** | **95.9%** (447/466) | **99.1%** (460/464) |

## 残る未到達行（意図的に対応せず）

残り4行はいずれも**実際には到達不能**と判断しました。テストのために無理に到達させる価値は無いと考えています。

| 箇所 | 理由 |
| --- | --- |
| `parser.dart:63,65` | シートを1つも持たないワークブックが必要だが、`excel` パッケージは最後のシートの削除を拒否するため（実際に試行して確認）、公開 API では構築できない。`Excel.decodeBytes` も有効な xlsx なら必ず1つ以上シートを返す |
| `export_runner.dart:228,229` | `_emitError` の3番目の分岐。`_buildEffectiveLogger` は「`logger` 自身」か「`logger` が `SimpleLogger` のときに限り新しい `SimpleLogger`」しか返さないため、先行する2条件のいずれかに必ず一致する |

どちらも防御的コードとして残す価値はあるため、削除ではなくこの記録に留めています。

## チェックリスト

- [x] テストを実行し、すべて成功した（102件パス。変更前は91件）
- [x] `dart analyze` を実行し、エラーや重要な警告を解消した（`No issues found!`）
- [x] カバレッジを測定し、必要があればテストを追加した（95.9% → 99.1%）
- [x] `CHANGELOG.md` を更新した — `LocalizationEntry` の等価比較の修正のみ記載。テスト追加は #38 で定めた基準により対象外
- [ ] `README.md` / `README_ja.md` を更新 — 外部仕様の変更が無いため対象外

## 実行ログ（要約）

```
fvm dart analyze                                       ->  No issues found!
fvm dart test                                          ->  All tests passed! (102)
fvm dart format --output=none --set-exit-if-changed .  ->  Formatted 36 files (0 changed)
fvm dart fix --dry-run                                 ->  Nothing to fix!
```

## 関連 Issue / PR

- #36 — FR-06 / FR-53 / FR-54 / FR-57 / FR-94 / FR-96 は本 PR で追加・修正したテストが対応する要件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
