### PR TITLE
refactor: stop deleting files during verify and narrow clean's scope

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,9 +38,7 @@ jobs:
         with:
           setup: true
       
-      - name: Install dependencies
-        run: fvm dart pub get
-      
+      # 依存の解決は scripts/verify.sh が行う（ローカルと同じ手順にするため）。
       - name: Install coverage tool
         run: fvm dart pub global activate coverage
       

--- a/doc/decisions.md
+++ b/doc/decisions.md
@@ -507,3 +507,48 @@ CLI は1回の実行でワークブックを2回デコードしていた。1回�
 `ExportCommand` の `logger` 引数は、公開クラスの引数でありながら公開 API ではないという状態が残る。ドキュメンテーションコメントで意図を明示し、ライブラリ利用時は CLI を経由せずコアを直接呼ぶよう案内した。
 
 参照: [PR #51](https://github.com/willow-c/locale_sheet/pull/51)
+
+---
+
+## ADR-17: 検証は何も削除せず、削除は既知のパスに限定する
+
+**状況**
+
+`make verify` は先頭で `clean` を呼んでいた。その `clean` は次の処理を含んでいた。
+
+```bash
+find . -type d -name l10n -exec rm -rf {} +
+find . -type f -name '*.arb' -delete
+```
+
+リポジトリ配下の `l10n` という名前のディレクトリと、すべての `.arb` ファイルを名前で全体検索して削除する。本パッケージの出力先は利用者が `--out` で自由に指定できるため、`./l10n` に出力していた開発者が「検証」のつもりで `make verify` を実行すると、作業結果を失う。
+
+さらに `clean` は `fvm flutter clean` を実行していた。本パッケージは `pubspec.yaml` に `flutter:` セクションを持たない純粋な Dart パッケージであり、Flutter ツールの起動（CI ログでは `Building flutter tool...` から始まる依存解決）が毎回発生していた。
+
+加えて CI は `fvm dart pub get` を実行した直後に `verify.sh` を呼び、その中の `clean` が `.dart_tool/` を削除していたため、解決結果が数秒で捨てられていた。`verify.sh` と `verify.ps1` で手順も揃っていなかった（`pub get` の有無）。
+
+**判断**
+
+- `verify` から `clean` の呼び出しを外す。検証は何も削除しない。
+- `clean` の削除対象を既知のパス（`.dart_tool/` `build/` `coverage/` `lib/l10n/` `example/out/`）に限定し、名前による全体検索をやめる。
+- `clean` から `flutter clean` を削除する。
+- `verify.sh` / `verify.ps1` の手順を揃え、どちらも `pub get` から始める。CI 側の重複した `pub get` ステップは削除する。
+
+**理由**
+
+「verify」という名前から削除は予期できない。破壊的な操作は、利用者が明示的に選んだときにだけ起きるべき。
+
+削除対象を名前で全体検索するのは、消してよいものを「名前が一致するかどうか」で判断していることになる。生成物の場所はこのリポジトリが決めているので、パスを直接指定すれば足りる。
+
+`flutter clean` が消すのは `build/` と `.dart_tool/` であり、`rm -rf` で置き換えられる。Flutter に依存しないパッケージのために Flutter ツールを起動する理由が無い。
+
+**採用しなかった案**
+
+- **`verify` から `clean` を残したまま、削除対象だけ限定する** — 範囲は狭まるが「検証したら消える」性質は残る。生成物であっても、検証のたびに消える必要は無い。
+- **CI 側だけ `clean` を呼ぶ** — CI は毎回まっさらなチェックアウトなので、そもそも不要。
+
+**影響**
+
+`make verify` の実行時間が短くなり（Flutter ツールの起動が無くなる）、実行しても作業ディレクトリのファイルが消えなくなる。まっさらな状態から検証したい場合は `make clean && make verify` と明示的に書く。
+
+参照: [PR #52](https://github.com/willow-c/locale_sheet/pull/52)

--- a/doc/developer/README.md
+++ b/doc/developer/README.md
@@ -21,6 +21,7 @@
 - fvm（Dart/Flutter バージョン管理。バージョンは `.fvmrc` で固定）
 - lcov（カバレッジHTMLレポート生成用。`genhtml` を使う）
 - `coverage` パッケージ（`scripts/coverage.sh` が `pub global run coverage:format_coverage` を使うため必須）
+- **git-lfs**（`example/*.xlsx` は `.gitattributes` で LFS 管理。未インストールのままクローンするとポインタファイルが置かれ、実ファイルを読む e2e テストが `Excel format unsupported` で失敗する）
 
 Homebrew でのインストール例（macOS）:
 
@@ -78,9 +79,19 @@ fvm dart pub global activate coverage
 ## CI / 開発フロー
 
 - `main` / `develop` への push と PR で [.github/workflows/verify.yml](../../.github/workflows/verify.yml) が実行される。
-- ワークフローは FVM で Flutter SDK を用意したうえで `scripts/verify.sh` を実行する。内訳は clean → format → `dart fix --dry-run` チェック → `dart analyze` → `dart test` → カバレッジ収集。
+- ワークフローは FVM で Flutter SDK を用意したうえで `scripts/verify.sh` を実行する。内訳は `pub get` → format → `dart fix --dry-run` チェック → `dart analyze` → `dart test` → カバレッジ収集。
 - カバレッジは Codecov にアップロードされ、`coverage/` は artifact として 30 日保持される。
 - ローカルでも同じ流れを `make verify`（Windows は `make.ps1 verify`）で再現できる。PR を出す前に実行しておくと CI での差し戻しを防げる。
+- **`verify` は生成物を削除しない。** 検証コマンドがファイルを消すのは予期できないため、削除は `make clean` に分離してある（ADR-17 を参照）。
+
+## clean が削除するもの
+
+`make clean`（Windows は `make.ps1 clean`）は、このリポジトリが生成する既知のパスだけを削除する。
+
+- `.dart_tool/` / `build/` / `coverage/`
+- `lib/l10n/` / `example/out/`（サンプル実行時の出力先）
+
+名前による全体検索は行わない。出力先は利用者が `--out` で自由に指定できるため、`*.arb` や `l10n` をリポジトリ全体から掃くと、利用者の作業結果まで消えてしまう。
 
 ## ExportCommand の注入方法（開発者向けサンプル）
 

--- a/scripts/clean.ps1
+++ b/scripts/clean.ps1
@@ -1,15 +1,30 @@
-# PowerShell: locale_sheet クリーンアップスクリプト
+# PowerShell: locale_sheet 生成物削除スクリプト
+#
+# 削除するのは、このリポジトリのビルド・テストが生成する既知のパスだけです。
+# 名前による全体検索（`Get-ChildItem -Recurse -Filter *.arb` など）は行いません。
+# 出力先は利用者が --out で自由に指定できるため、リポジトリ全体を掃くと
+# 利用者の作業結果まで消えてしまいます。
 $ErrorActionPreference = 'Stop'
-Write-Host "[locale_sheet] cleaning generated/test files..."
 
-# カバレッジ・テスト生成物
-Remove-Item -Recurse -Force coverage, .dart_tool -ErrorAction SilentlyContinue
+$root = Split-Path $PSScriptRoot -Parent
+Set-Location $root
 
-# l10n ディレクトリと .arb ファイル
-Get-ChildItem -Recurse -Directory -Filter l10n | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
-Get-ChildItem -Recurse -Filter *.arb | Remove-Item -Force -ErrorAction SilentlyContinue
+Write-Host "[locale_sheet] removing generated files..."
 
-# .DS_Store など
-Get-ChildItem -Recurse -Filter .DS_Store | Remove-Item -Force -ErrorAction SilentlyContinue
+$targets = @(
+    '.dart_tool',
+    'build',
+    'coverage',
+    'lib/l10n',
+    'example/out'
+)
+
+foreach ($target in $targets) {
+    $path = Join-Path $root $target
+    if (Test-Path $path) {
+        Remove-Item -Recurse -Force $path
+        Write-Host "  removed: $target"
+    }
+}
 
 Write-Host "[locale_sheet] clean done."

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,32 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# locale_sheet: 開発用クリーンアップスクリプト
+# locale_sheet: 生成物を削除するスクリプト
+#
+# 削除するのは、このリポジトリのビルド・テストが生成する既知のパスだけです。
+# 名前による全体検索（`find . -name '*.arb'` など）は行いません。出力先は
+# 利用者が `--out` で自由に指定できるため、リポジトリ全体を掃くと利用者の
+# 作業結果まで消えてしまいます。
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
 
-echo "[locale_sheet] cleaning generated/test files..."
+echo "[locale_sheet] removing generated files..."
 
-echo "[locale_sheet] running Flutter clean (fvm/flutter if available)"
-if command -v fvm >/dev/null 2>&1; then
-	echo "[locale_sheet] running: fvm flutter clean"
-	fvm flutter clean || true
-elif command -v flutter >/dev/null 2>&1; then
-	echo "[locale_sheet] running: flutter clean"
-	flutter clean || true
-else
-	echo "[locale_sheet] flutter が見つかりません (skipping flutter clean)"
-fi
+# pub / テストの生成物
+rm -rf .dart_tool/ build/ coverage/
 
-# カバレッジ・テスト生成物
-rm -rf coverage/
-rm -rf .dart_tool/
-
-# l10n/ ディレクトリや .arb ファイル（lib/l10n, test/l10n など）
-find . -type d -name l10n -exec rm -rf {} +
-find . -type f -name '*.arb' -delete
-
-# .DS_Store など不要ファイル
-find . -type f -name '.DS_Store' -delete
+# このリポジトリで生成されるローカライズ出力（.gitignore と対応）
+rm -rf lib/l10n/ example/out/
 
 echo "[locale_sheet] clean done."

--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -1,16 +1,23 @@
 <#
   PowerShell: verify.ps1
-  実行内容: format -> analyze -> test -> coverage
+  実行内容: format -> fix check -> analyze -> test -> coverage
+
+  生成物の削除は行いません。検証コマンドがファイルを消すのは予期できない
+  ためです。作業ディレクトリを綺麗にしたい場合は `make.ps1 clean` を
+  明示的に実行してください。
 #>
 
 $ErrorActionPreference = 'Stop'
 
 Write-Host "locale_sheet: verify (PowerShell)"
 
-function Invoke-LocalCommand($cmd, $args) {
-    Write-Host "Running: $cmd $($args -join ' ')"
-    $proc = Start-Process -FilePath $cmd -ArgumentList $args -NoNewWindow -Wait -PassThru
-    if ($proc.ExitCode -ne 0) { throw "Command failed: $cmd $($args -join ' ') (exit $($proc.ExitCode))" }
+# 引数名に $args を使うと PowerShell の自動変数を隠してしまうため避ける。
+function Invoke-LocalCommand($cmd, $commandArgs) {
+    Write-Host "Running: $cmd $($commandArgs -join ' ')"
+    $proc = Start-Process -FilePath $cmd -ArgumentList $commandArgs -NoNewWindow -Wait -PassThru
+    if ($proc.ExitCode -ne 0) {
+        throw "Command failed: $cmd $($commandArgs -join ' ') (exit $($proc.ExitCode))"
+    }
 }
 
 # choose fvm if available
@@ -20,14 +27,6 @@ if (Get-Command fvm -ErrorAction SilentlyContinue) {
 } else {
     $cmd = 'dart'
     $argsPrefix = @()
-}
-
-Write-Host "Running clean..."
-$cleanScript = Join-Path $PSScriptRoot 'clean.ps1'
-if (Test-Path $cleanScript) {
-    & $cleanScript
-} else {
-    Write-Host "clean.ps1 が見つかりません, skipping clean"
 }
 
 Write-Host "Resolving packages..."

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# verify.sh - run format -> analyze -> test -> coverage (mac/linux)
+# verify.sh - run format -> fix check -> analyze -> test -> coverage (mac/linux)
+#
+# 生成物の削除は行いません。検証コマンドがファイルを消すのは予期できない
+# ためです。作業ディレクトリを綺麗にしたい場合は `make clean` を明示的に
+# 実行してください。
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
 
@@ -11,12 +15,8 @@ else
     DART_CMD="dart"
 fi
 
-echo "[locale_sheet] running clean..."
-if [ -f ./scripts/clean.sh ] || [ -x ./scripts/clean.sh ]; then
-    ./scripts/clean.sh
-else
-    echo "[locale_sheet] ./scripts/clean.sh not found, skipping clean"
-fi
+echo "[locale_sheet] fetching packages..."
+eval $DART_CMD pub get
 
 echo "[locale_sheet] running format..."
 ./scripts/format.sh


### PR DESCRIPTION
## 概要 (Summary)

全体見直しで見つかった、ビルドスクリプト周りの4件（`verify` がファイルを削除する / CI が Flutter ツールをビルドする / `pub get` が捨てられる / sh と ps1 の非対称）をまとめて対応しました。

---

## 変更内容 (What)

- `verify` から `clean` の呼び出しを削除
- `clean` の削除対象を既知のパスに限定し、名前による全体検索を廃止
- `clean` から `flutter clean` を削除
- `verify.sh` / `verify.ps1` の手順を統一し、CI の重複した `pub get` を削除

## 理由 (Why)

### `make verify` が作業結果を消していた

`verify` は先頭で `clean` を呼び、その `clean` は次を実行していました。

```bash
find . -type d -name l10n -exec rm -rf {} +
find . -type f -name '*.arb' -delete
```

**リポジトリ配下の `l10n` という名前のディレクトリと、すべての `.arb` ファイルを名前で全体検索して削除**します。本パッケージの出力先は利用者が `--out` で自由に指定できるため、`./l10n` に出力していた開発者が「検証」のつもりで実行すると作業結果を失います。「verify」という名前から削除は予期できません。

### CI が Flutter ツールを起動していた

`clean` は `fvm flutter clean` を実行していました。しかし本パッケージは `pubspec.yaml` に `flutter:` セクションを持たない**純粋な Dart パッケージ**です（依存は `args` / `excel` / `meta`）。CI ログでは毎回 `Building flutter tool...` から始まる Flutter ツール本体の依存解決が走っていました。`flutter clean` が消すのは `build/` と `.dart_tool/` で、`rm -rf` で置き換えられます。

### `pub get` が直後に捨てられていた

CI は `fvm dart pub get` を実行してから `verify.sh` を呼びますが、その中の `clean` が `.dart_tool/` を削除するため、解決結果は数秒で消えていました。ワークフローを読んだ人は「依存は準備済み」と思うので実態と食い違います。

### sh と ps1 の非対称

`verify.ps1` は `pub get` を実行し、`verify.sh` は実行しませんでした。同じ `verify` で手順が違います。

## 変更項目の詳細（必須）

### 1. `clean` の対象限定と `flutter clean` の削除

- **変更内容**: 削除対象を `.dart_tool/` `build/` `coverage/` `lib/l10n/` `example/out/` の5つに固定。名前による全体検索と `flutter clean` を廃止。`clean.ps1` も同じ内容に揃え、削除したパスを表示するようにした。
- **理由**: 生成物の場所はこのリポジトリが決めているので、パスを直接指定すれば足ります。「名前が一致するかどうか」で消してよいかを判断するのは危険です。
- **差分への参照**: `scripts/clean.sh`, `scripts/clean.ps1`
- **テスト**: `l10n/keepme.arb` を置いた状態で両スクリプトを実行し、**削除されないこと**を確認しました（変更前は消えます）。`.dart_tool` と `lib/l10n` は期待どおり削除されます。
- **リスク/後続作業**: `build/` を追加したので、以前より対象が広い部分もあります（いずれも生成物）。

### 2. `verify` から `clean` を分離

- **変更内容**: `verify.sh` / `verify.ps1` から `clean` の呼び出しを削除し、どちらも `pub get` から始めるようにした。冒頭コメントに「生成物の削除は行わない」と明記。
- **理由**: 破壊的な操作は、利用者が明示的に選んだときにだけ起きるべきです。
- **差分への参照**: `scripts/verify.sh`, `scripts/verify.ps1`
- **テスト**: `./scripts/verify.sh` を実際に完走させ、133件パス・Flutter ツールの起動なしで `verify complete.` に到達することを確認しました。
- **リスク/後続作業**: まっさらな状態から検証したい場合は `make clean && make verify` と明示的に書く必要があります。

### 3. CI の重複ステップ削除

- **変更内容**: ワークフローの `Install dependencies` ステップを削除し、依存解決は `verify.sh` に一本化。
- **理由**: ローカルと CI で同じ手順にするためです。
- **差分への参照**: `.github/workflows/verify.yml`
- **テスト**: CI の実行で確認します。
- **リスク/後続作業**: なし。

### 4. `verify.ps1` の自動変数シャドウ

- **変更内容**: `function Invoke-LocalCommand($cmd, $args)` の引数名を `$commandArgs` に変更。
- **理由**: `$args` は PowerShell の自動変数で、引数名に使うと隠してしまいます。
- **差分への参照**: `scripts/verify.ps1`
- **テスト**: 挙動は変わりません。
- **リスク/後続作業**: なし。

## 設計判断の記録

`doc/decisions.md` に **ADR-17** として記録しました。採用しなかった案:

- **`verify` から `clean` を残したまま、削除対象だけ限定する** — 範囲は狭まるが「検証したら消える」性質は残る
- **CI 側だけ `clean` を呼ぶ** — CI は毎回まっさらなチェックアウトなので不要

## ドキュメントの更新

`doc/developer/README.md` に次を追記しました。

- `verify` は生成物を削除しないこと、削除は `make clean` に分離してあること
- `clean` が削除する対象の一覧と、名前による全体検索を行わない理由
- **開発に必要なツールに git-lfs を追加**（`example/*.xlsx` は LFS 管理。未インストールでクローンすると e2e テストが `Excel format unsupported` で失敗する。CI でも同じ問題が起きて #40 で `lfs: true` を追加した経緯がある）

## チェックリスト

- [x] テストを実行し、すべて成功した（133件パス。変更なし）
- [x] `dart analyze` を実行し、エラーや重要な警告を解消した（`No issues found!`）
- [x] カバレッジを測定し、必要があればテストを追加した（スクリプトの変更のため Dart のテストは追加なし。両スクリプトを実地で確認）
- [x] `CHANGELOG.md` を更新した — ADR-06 の基準により、開発スクリプトのみの変更のためエントリは追加していない
- [ ] `README.md` / `README_ja.md` を更新 — 外部仕様の変更が無いため対象外
- [x] 設計判断を伴う場合、`doc/decisions.md` に記録した（ADR-17）

## 関連 Issue / PR

- #40 — CI に `lfs: true` を追加した PR。git-lfs をドキュメントに追記したのは同じ問題の再発防止。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
