### PR TITLE
test: cover the exit paths Codecov flagged

### DIFF
--- a/test/src/cli/export_runner_test.dart
+++ b/test/src/cli/export_runner_test.dart
@@ -294,6 +294,91 @@ void main() {
     }
   });
 
+  /// 説明列に key を指定した場合、入力を読む前にEX_USAGE(64)で終わることを検証
+  /// Arrange-Act-Assertパターン
+  test('returns EX_USAGE when the description header is "key"', () async {
+    // Arrange: 1列目は必ずキー列なので、入力の内容に関わらず誤り
+    final logger = TestLogger();
+    final sheet = LocalizationSheet(locales: const ['en'], entries: []);
+    final parser = _FakeParser(sheet, sheets: ['Sheet1']);
+    final exporter = _FakeExporter();
+
+    // 入力ファイルは用意しない。読み込み前に弾かれることの確認を兼ねる。
+    final args = ExportCommand().argParser.parse([
+      '--input',
+      'test/no_such_file_should_not_be_read.xlsx',
+      '--format',
+      'arb',
+      '--out',
+      'outdir',
+      '--description-header',
+      'Key',
+    ]);
+
+    final runner = ExportRunner(
+      logger: logger,
+      parser: parser,
+      exporters: {'arb': exporter},
+    );
+
+    // Act
+    final res = await runner.run(args);
+
+    // Assert: 入力を読んでいれば EX_NOINPUT になるはずなので、
+    // EX_USAGE であることが「読む前に弾いた」ことの証明になる
+    expect(res, equals(exitUsage));
+    expect(
+      logger.errors.join('\n'),
+      contains("--description-header cannot be 'key'"),
+    );
+    expect(exporter.lastSheet, isNull);
+  });
+
+  /// 出力先を作成できない場合にEX_CANTCREAT(73)を返すことを検証
+  /// Arrange-Act-Assertパターン
+  test('returns EX_CANTCREAT when the output cannot be written', () async {
+    // Arrange: 既存のファイルを出力先に指定するとディレクトリを作れない
+    final logger = TestLogger();
+    final sheet = LocalizationSheet(
+      locales: const ['en'],
+      entries: [
+        LocalizationEntry('hello', const {'en': 'Hello'}),
+      ],
+    );
+    final parser = _FakeParser(sheet, sheets: ['Sheet1']);
+
+    final tmp = Directory.systemTemp.createTempSync('export_runner_cantcreat');
+    final input = File('${tmp.path}/in.xlsx')..writeAsBytesSync([0]);
+    final blocker = File('${tmp.path}/out')..writeAsStringSync('not a dir');
+
+    try {
+      final args = argParser().parse([
+        '--input',
+        input.path,
+        '--format',
+        'arb',
+        '--out',
+        blocker.path,
+      ]);
+
+      final runner = ExportRunner(
+        logger: logger,
+        parser: parser,
+        // 実物のエクスポーターを使う（書き込みの失敗を再現するため）
+        exporters: {'arb': ArbExporter()},
+      );
+
+      // Act
+      final res = await runner.run(args);
+
+      // Assert
+      expect(res, equals(exitCantCreate));
+      expect(logger.errors.join('\n'), contains('Cannot write output to'));
+    } finally {
+      tmp.deleteSync(recursive: true);
+    }
+  });
+
   /// 一部のオプションが定義されていないArgParserから得たArgResultsでも
   /// 例外にならず、未指定として扱われることを検証
   /// Arrange-Act-Assertパターン


### PR DESCRIPTION
## 概要 (Summary)

#54 に対する Codecov のパッチカバレッジ指摘（3行未到達）への対応です。指摘はいずれも妥当で、到達可能かつ未検証の経路でした。

---

## 変更内容 (What)

- `--description-header key` の事前検出（`EX_USAGE`）にテストを追加
- 出力書き込み失敗（`EX_CANTCREAT`）にテストを追加

## 理由 (Why)

#54 でエラー経路を細分化した際、次の2つにテストを付けていませんでした。

| 未到達だった箇所 | 経路 |
| --- | --- |
| `export_runner.dart:64` | `--description-header key` → `EX_USAGE`(64) |
| `export_runner.dart:109-110` | 出力を書き込めない → `EX_CANTCREAT`(73) |

Codecov の指摘（`lib/src/cli/export_runner.dart` のパッチカバレッジ 78.57%、3行 missing）はこの2箇所を正確に指していました。

## 変更項目の詳細（必須）

### 1. `--description-header key` のテスト

- **変更内容**: `returns EX_USAGE when the description header is "key"` を追加。
- **理由**: #54 で「入力を読む前に弾く」ことを設計判断として選んだにもかかわらず、それを固定するテストがありませんでした。
- **差分への参照**: `test/src/cli/export_runner_test.dart`
- **テスト**: **入力ファイルを存在しないパスにしています。** 読み込みを行っていれば `EX_NOINPUT`(66) になるはずなので、`EX_USAGE`(64) が返ることが「入力を読む前に弾いた」ことの証明になります。値は `Key`（大文字始まり）にして、大文字小文字を区別しない判定も同時に確認しています。
- **リスク/後続作業**: なし。

### 2. 出力書き込み失敗のテスト

- **変更内容**: `returns EX_CANTCREAT when the output cannot be written` を追加。既存のファイルを `--out` に指定し、ディレクトリ作成を失敗させます。実物の `ArbExporter` を使います（書き込みの失敗を再現するため）。
- **理由**: 同上。実 CLI でも同じ条件で `73` になることを確認済みです。
- **差分への参照**: `test/src/cli/export_runner_test.dart`
- **テスト**: 本項目がテスト。
- **リスク/後続作業**: OS によってエラーメッセージは異なりますが、検証しているのは終了コードと `Cannot write output to` の前置きなので、プラットフォームに依存しません。

## カバレッジ

| | 変更前 | 変更後 |
| --- | --- | --- |
| 全体 | 99.0%（561/567） | **99.3%（563/567）** |

残る未到達4行は、いずれも **ADR-05 で「実際には到達不能」と記録済み**のものです。

| 箇所 | 理由 |
| --- | --- |
| `parser.dart:127,129` | シートを持たないワークブックが必要だが、`excel` パッケージは最後のシートの削除を拒否するため公開 API では構築できない |
| `export_runner.dart:302,303` | `_emitError` の3番目の分岐。`_buildEffectiveLogger` の戻り値の性質上、先行する2条件のいずれかに必ず一致する |

到達させるために実装を歪める価値は無いという判断は変えていません。

## チェックリスト

- [x] テストを実行し、すべて成功した（145件パス。変更前は143件）
- [x] `dart analyze` を実行し、エラーや重要な警告を解消した（`No issues found!`）
- [x] カバレッジを測定し、必要があればテストを追加した（99.0% → 99.3%）
- [x] `CHANGELOG.md` を更新した — ADR-06 の基準により、テストのみの変更のためエントリは追加していない
- [ ] `README.md` / `README_ja.md` を更新 — 外部仕様の変更が無いため対象外
- [x] 設計判断を伴う場合、`doc/decisions.md` に記録した — 新たな判断は無し（ADR-05 の方針を踏襲）

## 関連 Issue / PR

- #54 — 本 PR が補うテストの対象。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
